### PR TITLE
Update gradle.properties

### DIFF
--- a/fabric/gradle.properties
+++ b/fabric/gradle.properties
@@ -20,7 +20,7 @@ org.gradle.daemon = false
 
 # Dependencies
   fabric_version = 0.83.1+1.20.1
-  forgeconfigapiport_version = 8.0.0
+  forgeconfigapiport_version = 20.2.4
 
 # Miscellaneous
   github_user = Nyphet


### PR DESCRIPTION
Update ForgeConfigAPI version to 20.2.4. Fails to load with latest 1.20.1 version.

```
Incompatible mods found!
net.fabricmc.loader.impl.FormattedException: Some of your mods are incompatible with the game or each other!
A potential solution has been determined, this may resolve your problem:
	 - Replace mod 'Forge Config API Port' (forgeconfigapiport) 20.2.4 with any version between 9.0.0 (inclusive) and 10- (exclusive).
More details:
	 - Mod 'Harvest with ease' (harvestwithease) 8.0.0.2 requires any version between 9.0.0 (inclusive) and 10- (exclusive) of mod 'Forge Config API Port' (forgeconfigapiport), but only the wrong version is present: 20.2.4!
	at net.fabricmc.loader.impl.FormattedException.ofLocalized(FormattedException.java:51) ~[fabric-loader-0.15.3.jar:?]
	at net.fabricmc.loader.impl.FabricLoaderImpl.load(FabricLoaderImpl.java:195) ~[fabric-loader-0.15.3.jar:?]
	at net.fabricmc.loader.impl.launch.knot.Knot.init(Knot.java:146) ~[fabric-loader-0.15.3.jar:?]
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:68) ~[fabric-loader-0.15.3.jar:?]
	at net.fabricmc.loader.impl.launch.knot.KnotServer.main(KnotServer.java:23) ~[fabric-loader-0.15.3.jar:?]
	at net.fabricmc.loader.impl.launch.server.FabricServerLauncher.main(FabricServerLauncher.java:69) ~[fabric-loader-0.15.3.jar:?]
	at net.fabricmc.installer.ServerLauncher.main(ServerLauncher.java:69) ~[fabric-1.20.2.jar:1.0.0]
```